### PR TITLE
Cmakepresets.json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
       run: cmake . --preset windows-${{ matrix.architecture }}-release
 
     - name: Test
-      run: ctest . --preset windows-${{ matrix.architecture }}-release
+      run: ctest . --preset windows-${{ matrix.architecture }}-release --build
 
     - name: Install
       run: cmake . --preset windows-${{ matrix.architecture }}-release --install --prefix ${{ github.workspace }}/out/install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    name: Build with CMake
+    name: Build
     
     env:
       DXSDK_DIR: "${{ github.workspace }}\\DXSDK"
@@ -65,20 +65,16 @@ jobs:
          dir /S /B DXSDK
 
     - name: Configure
-      working-directory: ${{ github.workspace }}/out/build
-      run: cmake -G Ninja ../.. -DORBITER_MAKE_DOC=OFF -DIRRKLANG_DIR:STRING="irrKlang_DOWNLOAD" -DDXSDK_DIR:PATH="${{ github.workspace }}\\DXSDK"
+      run: cmake . --preset windows-${{ matrix.architecture }}-release -DORBITER_MAKE_DOC=OFF -DIRRKLANG_DIR:STRING="irrKlang_DOWNLOAD" -DDXSDK_DIR:PATH="${{ github.workspace }}\\DXSDK"
 
     - name: Build
-      working-directory: ${{ github.workspace }}/out/build
-      run: cmake --build . --config RelWithDebInfo
+      run: cmake . --preset windows-${{ matrix.architecture }}-release
 
     - name: Test
-      working-directory: ${{ github.workspace }}/out/build
-      run: ctest --config RelWithDebInfo .
+      run: ctest . --preset windows-${{ matrix.architecture }}-release
 
     - name: Install
-      working-directory: ${{ github.workspace }}/out/build
-      run: cmake --install . --prefix  ${{ github.workspace }}/out/install
+      run: cmake . --preset windows-${{ matrix.architecture }}-release --install --prefix ${{ github.workspace }}/out/install
 
     - name: Pack
       if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,10 +68,10 @@ jobs:
       run: cmake . --preset windows-${{ matrix.architecture }}-release -DORBITER_MAKE_DOC=OFF -DIRRKLANG_DIR:STRING="irrKlang_DOWNLOAD" -DDXSDK_DIR:PATH="${{ github.workspace }}\\DXSDK"
 
     - name: Build
-      run: cmake . --preset windows-${{ matrix.architecture }}-release
+      run: cmake . --preset windows-${{ matrix.architecture }}-release --build
 
     - name: Test
-      run: ctest . --preset windows-${{ matrix.architecture }}-release --build
+      run: ctest . --preset windows-${{ matrix.architecture }}-release
 
     - name: Install
       run: cmake . --preset windows-${{ matrix.architecture }}-release --install --prefix ${{ github.workspace }}/out/install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,13 +68,13 @@ jobs:
       run: cmake . --preset windows-${{ matrix.architecture }}-release -DORBITER_MAKE_DOC=OFF -DIRRKLANG_DIR:STRING="irrKlang_DOWNLOAD" -DDXSDK_DIR:PATH="${{ github.workspace }}\\DXSDK"
 
     - name: Build
-      run: cmake . --preset windows-${{ matrix.architecture }}-release --build
+      run: cmake --build --preset windows-${{ matrix.architecture }}-release
 
     - name: Test
-      run: ctest . --preset windows-${{ matrix.architecture }}-release
+      run: ctest --preset windows-${{ matrix.architecture }}-release
 
     - name: Install
-      run: cmake . --preset windows-${{ matrix.architecture }}-release --install --prefix ${{ github.workspace }}/out/install
+      run: cmake --preset windows-${{ matrix.architecture }}-release --install --prefix ${{ github.workspace }}/out/install
 
     - name: Pack
       if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,13 +68,14 @@ jobs:
       run: cmake . --preset windows-${{ matrix.architecture }}-release -DORBITER_MAKE_DOC=OFF -DIRRKLANG_DIR:STRING="irrKlang_DOWNLOAD" -DDXSDK_DIR:PATH="${{ github.workspace }}\\DXSDK"
 
     - name: Build
-      run: cmake --build --preset windows-${{ matrix.architecture }}-release
+      run: cmake --build --preset windows-${{ matrix.architecture }}-release --jobs 2
 
     - name: Test
-      run: ctest --preset windows-${{ matrix.architecture }}-release
+      run: ctest --preset windows-${{ matrix.architecture }}-release --jobs 2
 
     - name: Install
-      run: cmake --preset windows-${{ matrix.architecture }}-release --install --prefix ${{ github.workspace }}/out/install
+      working-directory: ${{ github.workspace }}/out/build/windows-${{ matrix.architecture }}-release
+      run: cmake --install . --prefix ${{ github.workspace }}/out/install
 
     - name: Pack
       if: ${{ github.ref == 'refs/heads/main' }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,234 @@
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "ninja-base",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/out/build/${presetName}",
+      "installDir": "${sourceDir}/out/install/${presetName}"
+    },
+    {
+      "name": "windows-base",
+      "hidden": true,
+      "inherits": "ninja-base",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "cl",
+        "CMAKE_CXX_COMPILER": "cl",
+        "ORBITER_MAKE_DOC": "OFF"
+      },
+      "environment": {
+        "VCPKG_FEATURE_FLAGS": "manifests,versions,binarycaching,registries"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    },
+    {
+      "name": "linux-gcc-base",
+      "inherits": "ninja-base",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "gcc",
+        "CMAKE_CXX_COMPILER": "g++"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": [
+            "Linux"
+          ]
+        },
+        "microsoft.com/VisualStudioRemoteSettings/CMake/1.0": {
+          "sourceDir": "$env{HOME}/.vs/$ms{projectDirName}"
+        }
+      }
+    },
+    {
+      "name": "linux-clang-base",
+      "inherits": "linux-gcc-base",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++"
+      }
+    },
+    {
+      "name": "linux-x64-debug",
+      "displayName": "x64 Debug",
+      "inherits": "linux-clang-base",
+      "architecture": {
+        "value": "x64",
+        "strategy": "external"
+      },
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "linux-x64-release",
+      "displayName": "x64 Release",
+      "inherits": "linux-clang-base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "linux-x64-asan",
+      "displayName": "x64 ASan",
+      "inherits": "linux-x64-release",
+      "cacheVariables": {
+        "ORBITER_ENABLE_ASAN": true,
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
+      "name": "windows-x64-debug",
+      "displayName": "x64 Debug",
+      "inherits": "windows-base",
+      "architecture": {
+        "value": "x64",
+        "strategy": "external"
+      },
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "windows-x64-release",
+      "displayName": "x64 Release",
+      "inherits": "windows-x64-debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "windows-x64-asan",
+      "displayName": "x64 ASan",
+      "inherits": "windows-x64-release",
+      "cacheVariables": {
+        "ORBITER_ENABLE_ASAN": true,
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "windows-x86-debug",
+      "displayName": "x86 Debug",
+      "inherits": "windows-base",
+      "architecture": {
+        "value": "x86",
+        "strategy": "external"
+      },
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "windows-x86-release",
+      "displayName": "x86 Release",
+      "inherits": "windows-x86-debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "windows-x64-debug",
+      "displayName": "x64 Debug",
+      "configurePreset": "windows-x64-debug"
+    },
+    {
+      "name": "windows-x64-release",
+      "displayName": "x64 Release",
+      "configurePreset": "windows-x64-release"
+    },
+    {
+      "name": "windows-x64-asan",
+      "displayName": "x64 ASan",
+      "configurePreset": "windows-x64-asan"
+    },
+    {
+      "name": "windows-x86-debug",
+      "displayName": "x86 Debug",
+      "configurePreset": "windows-x86-debug"
+    },
+    {
+      "name": "windows-x86-release",
+      "displayName": "x86 Release",
+      "configurePreset": "windows-x86-release"
+    },
+    {
+      "name": "linux-x64-debug",
+      "displayName": "x64 Debug",
+      "configurePreset": "linux-x64-debug"
+    },
+    {
+      "name": "linux-x64-release",
+      "displayName": "x64 Release",
+      "configurePreset": "linux-x64-release"
+    },
+    {
+      "name": "linux-x64-asan",
+      "displayName": "x64 ASan",
+      "configurePreset": "linux-x64-asan"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "test-base",
+      "description": "Enable output on failure",
+      "configurePreset": "ninja-base",
+      "hidden": true,
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "windows-x64-debug",
+      "configurePreset": "windows-x64-debug",
+      "inherits": "test-base"
+    },
+    {
+      "name": "windows-x64-release",
+      "configurePreset": "windows-x64-release",
+      "inherits": "test-base"
+    },
+    {
+      "name": "windows-x64-asan",
+      "configurePreset": "windows-x64-asan",
+      "inherits": "test-base"
+    },
+    {
+      "name": "windows-x86-debug",
+      "configurePreset": "windows-x86-debug",
+      "inherits": "test-base"
+    },
+    {
+      "name": "windows-x86-release",
+      "configurePreset": "windows-x86-release",
+      "inherits": "test-base"
+    },
+    {
+      "name": "linux-x64-debug",
+      "configurePreset": "linux-x64-debug",
+      "inherits": "test-base"
+    },
+    {
+      "name": "linux-x64-release",
+      "configurePreset": "linux-x64-release",
+      "inherits": "test-base"
+    },
+    {
+      "name": "linux-x64-asan",
+      "configurePreset": "linux-x64-asan",
+      "inherits": "test-base"
+    }
+  ]
+}


### PR DESCRIPTION
Resurrecting old PR with adding presets. Rationale:

- Reduce entry barrier for new developers (plug-and-play in Visual Studio 2019/2022)
- Add ability to perform consistent builds (ideally documentation on/off flags should also be moved to presets)
- Provide basic template for Linux debugging from VS (not relevant now, but may be useful in future)